### PR TITLE
remove GET endpoints and location header

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show update destroy]
-
-  def index
-    @users = User.all
-    render json: @users
-  end
-
-  def show
-    render json: @user
-  end
+  before_action :set_user, only: %i[update destroy]
 
   def create
     @user = User.new(user_params)
@@ -18,7 +9,7 @@ class UsersController < ApplicationController
       NotifyMailer.new_api_key_request(@user).deliver_later
       #TODO Mock out Google Auth for end-to-end tests
       AnalyticsUpdateService.new.add_new_service(@user[:api_key], @user[:department], @user[:service]) unless Rails.env.test?
-      render json: @user, status: :created, location: @user
+      render json: @user, status: :created
     else
       render json: @user.errors, status: :unprocessable_entity
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,4 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[update destroy]
-
   def create
     @user = User.new(user_params)
 
@@ -15,27 +13,7 @@ class UsersController < ApplicationController
     end
   end
 
-  def update
-    if @user.update(user_params)
-      render json: @user, status: :ok
-      head :no_content
-    else
-      render json: @user.errors, status: :unprocessable_entity
-    end
-  end
-
-  def destroy
-    @user.destroy
-    head :no_content
-  end
-
 private
-
-  def set_user
-    @user = User.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "User not found" }, status: :not_found
-  end
 
   def user_params
     params.permit(:email, :service, :department, :api_key)

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -4,47 +4,6 @@ RSpec.describe 'Users API', type: :request do
   let!(:users) { create_list(:user, 10) }
   let(:user_id) { users.first.id }
 
-  describe 'GET /users' do
-    before { get '/users' }
-
-    it 'returns users' do
-      # Note `json` is a custom helper to parse JSON responses
-      expect(json).not_to be_empty
-      expect(json.size).to eq(10)
-    end
-
-    it 'returns status code 200' do
-      expect(response).to have_http_status(200)
-    end
-  end
-
-  describe 'GET /users/:id' do
-    before { get "/users/#{user_id}" }
-
-    context 'when the record exists' do
-      it 'returns the user' do
-        expect(json).not_to be_empty
-        expect(json['id']).to eq(user_id)
-      end
-
-      it 'returns status code 200' do
-        expect(response).to have_http_status(200)
-      end
-    end
-
-    context 'when the record does not exist' do
-      let(:user_id) { 100 }
-
-      it 'returns status code 404' do
-        expect(response).to have_http_status(404)
-      end
-
-      it 'returns a not found message' do
-        expect(response.body).to match(/User not found/)
-      end
-    end
-  end
-
   describe 'POST /users' do
     let(:valid_attributes) { { email: 'admin@gov.uk' } }
 
@@ -70,31 +29,6 @@ RSpec.describe 'Users API', type: :request do
       it 'returns a validation failure message' do
         expect(response.body).to include("can't be blank")
       end
-    end
-  end
-
-  describe 'PUT /users/:id' do
-    let(:valid_attributes) { { email: 'admin2@gov.uk' } }
-
-    context 'when the record exists' do
-      before { put "/users/#{user_id}", params: valid_attributes }
-
-      it 'updates the record' do
-        expect(response.body).to be_empty
-      end
-
-      it 'returns status code 204' do
-        expect(response).to have_http_status(204)
-      end
-    end
-  end
-
-
-  describe 'DELETE /users/:id' do
-    before { delete "/users/#{user_id}" }
-
-    it 'returns status code 204' do
-      expect(response).to have_http_status(204)
     end
   end
 end


### PR DESCRIPTION
### Context
Required for security before launch

### Changes proposed in this pull request
Remove GET, PUT and DELETE endpoints

### Guidance to review
Should not be able to GET user list or individual user details.

Note, we may re-add this functionality in future behind auth but for now it is simplest to remove it.