### PR TITLE
Add basic http auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
 class ApplicationController < ActionController::API
   include ActionController::Serialization
+
+  include ActionController::HttpAuthentication::Basic::ControllerMethods
+  http_basic_authenticate_with name: Rails.application.secrets.http_auth_username, password: Rails.application.secrets.http_auth_password
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,15 +22,21 @@ development:
   spreadsheet_id: "1t5bbuSmDtRueSyD-8X1i3aX3E9t1uWv48n4mk28akGE"
   spreadsheet_range: "Sheet1!A2:C"
   google_api_key: <%= ENV['GOOGLE_CREDENTIALS_JSON'] %>
+  http_auth_username: 'username'
+  http_auth_password: 'password'
 
 test:
   secret_key_base: 143041fdebb68ea9b26c6af7d99030e636328294c073ab4fd5b8b7ba4b0edb7799cbf4e1201006debdd7ea89d8e09eee536a66d8e01887c5bfd69b1867b7633e
   spreadsheet_id: "1t5bbuSmDtRueSyD-8X1i3aX3E9t1uWv48n4mk28akGE"
   spreadsheet_range: "Sheet1!A2:C"
   google_api_key: <%= ENV['GOOGLE_CREDENTIALS_JSON'] %>
+  http_auth_username: 'username'
+  http_auth_password: 'password'
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   spreadsheet_id: "1M8kXcbfDCgk1s1SRZMvt2r3nzjUCphbbgCpSMYz4Rh8"
   spreadsheet_range: "Sheet1!A2:C"
   google_api_key: <%= ENV['GOOGLE_CREDENTIALS_JSON'] %>
+  http_auth_username: <%= ENV['HTTP_AUTH_USERNAME'] %>
+  http_auth_password: <%= ENV['HTTP_AUTH_PASSWORD'] %>

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 RSpec.describe 'Users API', type: :request do
   let!(:users) { create_list(:user, 10) }
   let(:user_id) { users.first.id }
+  let(:headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(Rails.application.secrets.http_auth_username, Rails.application.secrets.http_auth_password) } }
 
   describe 'POST /users' do
     let(:valid_attributes) { { email: 'admin@gov.uk' } }
 
     context 'when the request is valid' do
-      before { post '/users', params: valid_attributes }
+      before { post '/users', params: valid_attributes, headers: headers }
 
       it 'creates a user' do
         expect(json['email']).to eq('admin@gov.uk')
@@ -20,7 +21,7 @@ RSpec.describe 'Users API', type: :request do
     end
 
     context 'when the request is invalid' do
-      before { post '/users', params: { email: nil } }
+      before { post '/users', params: { email: nil }, headers: headers }
 
       it 'returns status code 422' do
         expect(response).to have_http_status(422)


### PR DESCRIPTION
### Changes proposed in this pull request
We want to lock down access to the service

### Guidance to review
Start the server and attempt to post i.e. `http POST :3001/users email=admin@gov.uk`