### PR TITLE
use released govuk-lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ group :development, :test do
 
   gem 'rspec-rails', '~> 3.5'
 
-  gem 'govuk-lint', github: 'alphagov/govuk-lint', branch: 'master'
+  gem 'govuk-lint', '~> 3.8'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/govuk-lint.git
-  revision: a51882f21ff91a1af58da2e1c55d201880645193
-  branch: master
-  specs:
-    govuk-lint (3.7.0)
-      rubocop (~> 0.52.0)
-      rubocop-rspec (~> 1.19.0)
-      scss_lint
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -100,6 +90,10 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    govuk-lint (3.8.0)
+      rubocop (~> 0.52.0)
+      rubocop-rspec (~> 1.19.0)
+      scss_lint
     govuk-registers-api-client (1.0.1)
       rest-client (~> 2)
     govuk_notify_rails (2.0.0)
@@ -274,7 +268,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.0)
   faker
   google-api-client
-  govuk-lint!
+  govuk-lint (~> 3.8)
   govuk-registers-api-client (~> 1.0)
   govuk_notify_rails
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
### Context
Previously we were pointing to `master`

### Changes proposed in this pull request
use latest released govuk-lint

### Guidance to review
Build should still pass in travis
