### PR TITLE
in sheet use (not set) if nil in submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'govuk_notify_rails'
 gem 'cf-app-utils'
 
 gem 'govuk-registers-api-client', '~> 1.0'
+gem 'nilify_blanks', '~> 1.3'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,9 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     netrc (0.11.0)
+    nilify_blanks (1.3.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -272,6 +275,7 @@ DEPENDENCIES
   govuk-registers-api-client (~> 1.0)
   govuk_notify_rails
   listen (>= 3.0.5, < 3.2)
+  nilify_blanks (~> 1.3)
   pg (~> 0.18)
   pry-byebug
   puma (~> 3.7)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ require 'register_client_manager'
 
 class User < ApplicationRecord
   before_save :set_api_key
+  nilify_blanks
 
   validates :email, presence: true
 
@@ -12,7 +13,7 @@ class User < ApplicationRecord
       record = register_data.get_records.find { |r| department == r.entry.key }
       record.item.value['name']
     else
-      ""
+      nil
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,6 @@ class User < ApplicationRecord
       register_data = registers_client.get_register('government-organisation', 'beta')
       record = register_data.get_records.find { |r| department == r.entry.key }
       record.item.value['name']
-    else
-      nil
     end
   end
 

--- a/app/services/analytics_update_service.rb
+++ b/app/services/analytics_update_service.rb
@@ -13,7 +13,9 @@ class AnalyticsUpdateService
     @service.authorization = authorization
   end
 
-  def add_new_service(api_key, department = 'Not available', service = 'Not available', options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
+  def add_new_service(api_key, department, service, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
+    department ||= '(not set)'
+    service ||= '(not set)'
     value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, service]])
     @service.append_spreadsheet_value(options[:spreadsheet_id], options[:range], value_range, value_input_option: 'RAW')
   end


### PR DESCRIPTION
### Context
Requested by Dan Gilbert

### Changes proposed in this pull request
This is apparently a Google Analytics convention if there is no value we set literal `(not set)` in the custom dimension.

### Guidance to review
Request an API key without specifying Department or Service, value in sheet should be *(not set)*
