### PR TITLE
Api key updates

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
       NotifyMailer.api_key_confirmation(@user).deliver_later
       NotifyMailer.new_api_key_request(@user).deliver_later
       #TODO Mock out Google Auth for end-to-end tests
-      AnalyticsUpdateService.new.add_new_service(@user[:api_key], @user.department_name, @user[:service], @user[:is_government]) unless Rails.env.test?
+      AnalyticsUpdateService.new.add_new_service(@user[:api_key], @user.department_name, @user[:non_gov_use_category], @user[:is_government]) unless Rails.env.test?
       render json: @user, status: :created
     else
       render json: @user.errors, status: :unprocessable_entity
@@ -16,6 +16,6 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.permit(:email, :service, :department, :api_key, :is_government)
+    params.permit(:email, :non_gov_use_category, :department, :api_key, :is_government)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,11 +3,11 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      NotifyMailer.api_key_confirmation(@user).deliver_later
-      NotifyMailer.new_api_key_request(@user).deliver_later
       #TODO Mock out Google Auth for end-to-end tests
       AnalyticsUpdateService.new.add_new_service(@user[:api_key], @user.department_name, @user[:non_gov_use_category], @user[:is_government]) unless Rails.env.test?
       render json: @user, status: :created
+      NotifyMailer.api_key_confirmation(@user).deliver_later
+      NotifyMailer.new_api_key_request(@user).deliver_later
     else
       render json: @user.errors, status: :unprocessable_entity
     end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -16,7 +16,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
       email: user.email,
       api_key: user.api_key,
       department: user.department_name,
-      service: user.service
+      non_gov_use_category: user.non_gov_use_category
     )
 
     mail(to: 'registerteam@digital.cabinet-office.gov.uk')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,10 @@ class User < ApplicationRecord
 
   def department_name
     if department.present?
+      curie = department.split(':')
       registers_client = RegistersClient::RegisterClientManager.new
-      register_data = registers_client.get_register('government-organisation', 'beta')
-      record = register_data.get_records.find { |r| department == r.entry.key }
+      register_data = registers_client.get_register(curie[0], 'beta')
+      record = register_data.get_records.find { |r| curie[1] == r.entry.key }
       record.item.value['name']
     end
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :email, :service, :department, :api_key, :is_government
+  attributes :email, :non_gov_use_category, :department, :api_key, :is_government
 end

--- a/app/services/analytics_update_service.rb
+++ b/app/services/analytics_update_service.rb
@@ -15,7 +15,7 @@ class AnalyticsUpdateService
 
   def add_new_service(api_key, department, non_gov_use_category, is_government, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
     department ||= is_government == false ? 'Non government' : '(not set)'
-    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category ? "Non-Government - #{non_gov_use_category.humanize}" : 'Government']])
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, !is_government ? "Non-Government - #{non_gov_use_category.humanize}" : 'Government']])
     @service.append_spreadsheet_value(options[:spreadsheet_id], options[:range], value_range, value_input_option: 'RAW')
   end
 end

--- a/app/services/analytics_update_service.rb
+++ b/app/services/analytics_update_service.rb
@@ -15,8 +15,7 @@ class AnalyticsUpdateService
 
   def add_new_service(api_key, department, non_gov_use_category, is_government, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
     department ||= is_government == false ? 'Non government' : '(not set)'
-    non_gov_use_category ||= '(not set)'
-    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category]])
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category ? "Non-Government - #{non_gov_use_category.gsub'_',' '}" : 'Government']])
     @service.append_spreadsheet_value(options[:spreadsheet_id], options[:range], value_range, value_input_option: 'RAW')
   end
 end

--- a/app/services/analytics_update_service.rb
+++ b/app/services/analytics_update_service.rb
@@ -15,7 +15,7 @@ class AnalyticsUpdateService
 
   def add_new_service(api_key, department, non_gov_use_category, is_government, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
     department ||= is_government == false ? 'Non government' : '(not set)'
-    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category ? "Non-Government - #{non_gov_use_category.tr'_', ' '}" : 'Government']])
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category ? "Non-Government - #{non_gov_use_category.humanize}" : 'Government']])
     @service.append_spreadsheet_value(options[:spreadsheet_id], options[:range], value_range, value_input_option: 'RAW')
   end
 end

--- a/app/services/analytics_update_service.rb
+++ b/app/services/analytics_update_service.rb
@@ -15,7 +15,7 @@ class AnalyticsUpdateService
 
   def add_new_service(api_key, department, non_gov_use_category, is_government, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
     department ||= is_government == false ? 'Non government' : '(not set)'
-    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category ? "Non-Government - #{non_gov_use_category.gsub'_',' '}" : 'Government']])
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category ? "Non-Government - #{non_gov_use_category.tr'_', ' '}" : 'Government']])
     @service.append_spreadsheet_value(options[:spreadsheet_id], options[:range], value_range, value_input_option: 'RAW')
   end
 end

--- a/app/services/analytics_update_service.rb
+++ b/app/services/analytics_update_service.rb
@@ -13,10 +13,10 @@ class AnalyticsUpdateService
     @service.authorization = authorization
   end
 
-  def add_new_service(api_key, department, service, is_government, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
+  def add_new_service(api_key, department, non_gov_use_category, is_government, options = { spreadsheet_id: Rails.application.secrets.spreadsheet_id, range: Rails.application.secrets.spreadsheet_range })
     department ||= is_government == false ? 'Non government' : '(not set)'
-    service ||= '(not set)'
-    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, service]])
+    non_gov_use_category ||= '(not set)'
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: [[api_key, department, non_gov_use_category]])
     @service.append_spreadsheet_value(options[:spreadsheet_id], options[:range], value_range, value_input_option: 'RAW')
   end
 end

--- a/db/migrate/20180508111824_rename_service_to_non_gov_use_category.rb
+++ b/db/migrate/20180508111824_rename_service_to_non_gov_use_category.rb
@@ -1,0 +1,5 @@
+class RenameServiceToNonGovUseCategory < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :users, :service, :non_gov_use_category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180427160730) do
+ActiveRecord::Schema.define(version: 20180508111824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
     t.string "email"
-    t.string "service"
+    t.string "non_gov_use_category"
     t.string "department"
     t.uuid "api_key"
     t.datetime "created_at", null: false

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
-    service { Faker::Company.name }
+    non_gov_use_category 'Personal'
     department { Faker::Company.name }
   end
 end


### PR DESCRIPTION
### Context
We no longer collect the service of a gov org but we want to find out why a non-gov org is wanting an API key.

### Changes proposed in this pull request
Rename `service` db column to `non_gov_use_category `

### Guidance to review
Fire up `update-api-key-form` on `registers-frontend` and follow the API key flow as per https://github.com/openregister/registers-frontend/pull/292