### PR TITLE
Send confirmation email for downloads

### DIFF
--- a/app/controllers/download_users_controller.rb
+++ b/app/controllers/download_users_controller.rb
@@ -4,6 +4,7 @@ class DownloadUsersController < ApplicationController
 
     if @download_user.save
       render json: @download_user, status: :created
+      NotifyMailer.register_download_confirmation(@download_user).deliver_later
     else
       render json: @download_user.errors, status: :unprocessable_entity
     end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -21,4 +21,15 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     mail(to: 'registerteam@digital.cabinet-office.gov.uk')
   end
+
+  def register_download_confirmation(download_user)
+    set_template('67a7d2f9-3faf-431a-a2a1-812f40a72e22')
+
+    set_personalisation(
+      register_name: download_user.register.capitalize,
+      register_download_link: "https://www.registers.service.gov.uk/registers/#{download_user.register.parameterize}/download-csv"
+    )
+
+    mail(to: download_user.email)
+  end
 end


### PR DESCRIPTION
### Changes proposed in this pull request
Send an email via GOV.UK Notify when a user downloads a register

### Guidance to review
Complete the download journey on the frontend.

![screen shot 2018-05-25 at 13 37 01](https://user-images.githubusercontent.com/3071606/40544610-d4612472-6020-11e8-8328-21b210abef9a.png)

