### PR TITLE
Remove api key mailer currently sent to the team

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,6 @@ class UsersController < ApplicationController
       render json: @user, status: :created
       if @user.email.present?
         NotifyMailer.api_key_confirmation(@user).deliver_later
-        NotifyMailer.new_api_key_request(@user).deliver_later
       end
     else
       render json: @user.errors, status: :unprocessable_entity

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -8,17 +8,4 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     mail(to: user.email)
   end
-
-  def new_api_key_request(user)
-    set_template('926a72b2-1332-4e88-a322-adee7c522203')
-
-    set_personalisation(
-      email: user.email,
-      api_key: user.api_key,
-      department: user.department_name,
-      non_gov_use_category: user.non_gov_use_category
-    )
-
-    mail(to: 'registerteam@digital.cabinet-office.gov.uk')
-  end
 end


### PR DESCRIPTION
### Context
GDPR

### Changes proposed in this pull request
Remove api key mailer sent to registers team

### Guidance to review
Create API key, only the user should get an email