### PR TITLE
Add register to users table

### DIFF
--- a/app/controllers/download_users_controller.rb
+++ b/app/controllers/download_users_controller.rb
@@ -1,6 +1,7 @@
 class DownloadUsersController < ApplicationController
   def create
-    @download_user = DownloadUser.new(download_user_params)
+    @download_user = User.new(user_params)
+    @download_user.contactable = true
 
     if @download_user.save
       render json: @download_user, status: :created
@@ -11,7 +12,7 @@ class DownloadUsersController < ApplicationController
 
 private
 
-  def download_user_params
-    params.permit(:email, :non_gov_use_category, :department, :is_government, :register)
+  def user_params
+    params.permit(:email, :non_gov_use_category, :department, :api_key, :is_government, :contactable, :register)
   end
 end

--- a/app/controllers/download_users_controller.rb
+++ b/app/controllers/download_users_controller.rb
@@ -1,6 +1,7 @@
 class DownloadUsersController < ApplicationController
   def create
     @download_user = User.new(user_params)
+    @download_user.user_type = :download
     @download_user.contactable = true
 
     if @download_user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.api_key = SecureRandom.uuid
+    @user.user_type = :api
 
     if @user.save
       #TODO Mock out Google Auth for end-to-end tests
@@ -19,6 +20,6 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.permit(:email, :non_gov_use_category, :department, :api_key, :is_government, :contactable, :register)
+    params.permit(:email, :non_gov_use_category, :department, :api_key, :is_government, :contactable)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
+    @user.api_key = SecureRandom.uuid
 
     if @user.save
       #TODO Mock out Google Auth for end-to-end tests
@@ -18,6 +19,6 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.permit(:email, :non_gov_use_category, :department, :api_key, :is_government, :contactable)
+    params.permit(:email, :non_gov_use_category, :department, :api_key, :is_government, :contactable, :register)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,17 +1,8 @@
 require 'register_client_manager'
 
 class User < ApplicationRecord
-  before_save :set_api_key
   nilify_blanks
   validates :contactable, inclusion: { in: [true, false] }, if: -> { is_government == true }
   validates :email, presence: true, if: -> { is_government == true }
   include ModelHelpers
-
-private
-
-  def set_api_key
-    if self.api_key.blank?
-      self.api_key = SecureRandom.uuid
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
   validates :contactable, inclusion: { in: [true, false] }, if: -> { is_government == true }
   validates :email, presence: true, if: -> { is_government == true }
   include ModelHelpers
+  enum user_type: [:api, :download ]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,5 @@ class User < ApplicationRecord
   validates :contactable, inclusion: { in: [true, false] }, if: -> { is_government == true }
   validates :email, presence: true, if: -> { is_government == true }
   include ModelHelpers
-  enum user_type: [:api, :download ]
+  enum user_type: %i[api download]
 end

--- a/db/migrate/20180612082319_add_register_to_users.rb
+++ b/db/migrate/20180612082319_add_register_to_users.rb
@@ -1,0 +1,5 @@
+class AddRegisterToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :register, :string
+  end
+end

--- a/db/migrate/20180612082738_move_download_users_to_users.rb
+++ b/db/migrate/20180612082738_move_download_users_to_users.rb
@@ -1,0 +1,22 @@
+class MoveDownloadUsersToUsers < ActiveRecord::Migration[5.1]
+  def change
+    DownloadUsers.find_each do |download_user|
+      download_user.users.create(
+        email: download_user.email,
+        register: download_user.register,
+        non_gov_use_category: download_user.non_gov_use_category,
+        department: download_user.department,
+        is_government: download_user.is_government
+      )
+    end
+
+    # execute <<-SQL_END
+    #   INSERT INTO users (email, register, department, is_government, non_gov_use_category)
+
+
+    #   SELECT 'DownloadUser', email, register, department, is_government, non_gov_use_category
+
+    #   FROM workshops;
+    # SQL_END
+  end
+end

--- a/db/migrate/20180612082738_move_download_users_to_users.rb
+++ b/db/migrate/20180612082738_move_download_users_to_users.rb
@@ -1,22 +1,15 @@
 class MoveDownloadUsersToUsers < ActiveRecord::Migration[5.1]
   def change
-    DownloadUsers.find_each do |download_user|
-      download_user.users.create(
+    DownloadUser.find_each do |download_user|
+      User.create(
         email: download_user.email,
         register: download_user.register,
         non_gov_use_category: download_user.non_gov_use_category,
         department: download_user.department,
-        is_government: download_user.is_government
+        is_government: download_user.is_government,
+        api_key: nil,
+        contactable: false
       )
     end
-
-    # execute <<-SQL_END
-    #   INSERT INTO users (email, register, department, is_government, non_gov_use_category)
-
-
-    #   SELECT 'DownloadUser', email, register, department, is_government, non_gov_use_category
-
-    #   FROM workshops;
-    # SQL_END
   end
 end

--- a/db/migrate/20180612082738_move_download_users_to_users.rb
+++ b/db/migrate/20180612082738_move_download_users_to_users.rb
@@ -8,7 +8,7 @@ class MoveDownloadUsersToUsers < ActiveRecord::Migration[5.1]
         department: download_user.department,
         is_government: download_user.is_government,
         api_key: nil,
-        contactable: false
+        contactable: download_user.created_at.between?(Time.utc(2018, 0o5, 30, 18), Time.now)
       )
     end
   end

--- a/db/migrate/20180614133521_add_user_type.rb
+++ b/db/migrate/20180614133521_add_user_type.rb
@@ -1,0 +1,5 @@
+class AddUserType < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :user_type, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614133954) do
+ActiveRecord::Schema.define(version: 20180614133521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180612082319) do
+ActiveRecord::Schema.define(version: 20180612082738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180531153702) do
+ActiveRecord::Schema.define(version: 20180612082319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20180531153702) do
     t.datetime "updated_at", null: false
     t.boolean "is_government"
     t.boolean "contactable"
+    t.string "register"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180612082738) do
+ActiveRecord::Schema.define(version: 20180614133954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20180612082738) do
     t.boolean "is_government"
     t.boolean "contactable"
     t.string "register"
+    t.integer "user_type"
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
+    is_government true
     email { Faker::Internet.email }
-    non_gov_use_category 'Personal'
     department { Faker::Company.name }
     contactable true
   end

--- a/spec/models/download_user_spec.rb
+++ b/spec/models/download_user_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe DownloadUser, type: :model do
-  it { should validate_presence_of(:email) }
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe User, type: :model do
   context 'is a government user' do
     before { allow(subject).to receive(:is_government).and_return(true) }
     it { should validate_presence_of(:email) }
-    it { should validate_inclusion_of(:contactable).in_array([true, false]) }
   end
 
   context 'is not a government user' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   context 'is a government user' do
     before { allow(subject).to receive(:is_government).and_return(true) }
-    it { should validate_presence_of(:email)}
+    it { should validate_presence_of(:email) }
     it { should validate_inclusion_of(:contactable).in_array([true, false]) }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context 'is a government user' do
+    before { allow(subject).to receive(:is_government).and_return(true) }
+    it { should validate_presence_of(:email)}
+    it { should validate_inclusion_of(:contactable).in_array([true, false]) }
+  end
+
+  context 'is not a government user' do
+    before { allow(subject).to receive(:is_government).and_return(false) }
+    it { should_not validate_presence_of(:email) }
+  end
+end

--- a/spec/requests/download_users_spec.rb
+++ b/spec/requests/download_users_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Download Users API', type: :request do
-  let!(:download_users) { create_list(:user, 10) }
-  let(:user_id) { download_users.first.id }
+  let!(:users) { create_list(:user, 10) }
+  let(:user_id) { users.first.id }
   let(:headers) { { 'Authorization' => ActionController::HttpAuthentication::Basic.encode_credentials(Rails.application.secrets.http_auth_username, Rails.application.secrets.http_auth_password) } }
 
   describe 'POST /download_users' do
-    let(:valid_attributes) { { email: 'admin@gov.uk' } }
+    let(:valid_attributes) { { email: 'admin@gov.uk', contactable: true } }
 
     context 'when the request is valid' do
       before { post '/download_users', params: valid_attributes, headers: headers }
@@ -21,7 +21,7 @@ RSpec.describe 'Download Users API', type: :request do
     end
 
     context 'when the request is invalid' do
-      before { post '/download_users', params: { email: nil }, headers: headers }
+      before { post '/download_users', params: { email: nil, is_government: true }, headers: headers }
 
       it 'returns status code 422' do
         expect(response).to have_http_status(422)


### PR DESCRIPTION
### Context
No need to separate `users` and `download_users` in the database.

### Changes proposed in this pull request
- Add `register` attr to `users` table
- Migrate all date from `download_users` into `users`
- Update `download_users` controller to save to `users` table
- Fix specs

### Guidance to review
Running the migrations should copy the data from `download_users` into `users` and completing the download form and api key form on the frontend should results in the data being saved to the `users` table