### PR TITLE
add migration to backfill user type

### DIFF
--- a/db/migrate/20180620133920_backfill_user_type.rb
+++ b/db/migrate/20180620133920_backfill_user_type.rb
@@ -1,6 +1,11 @@
 class BackfillUserType < ActiveRecord::Migration[5.1]
   def change
-    User.where(user_type: nil).where.not(api_key: nil).update_all(user_type: :api)
-    User.where(api_key: nil, user_type: nil).update_all(user_type: :download)
+    User.where(user_type: nil).find_each do |u|
+      if u.api_key.present?
+        u.update(user_type: :api)
+      else
+        u.update(user_type: :download)
+      end
+    end
   end
 end

--- a/db/migrate/20180620133920_backfill_user_type.rb
+++ b/db/migrate/20180620133920_backfill_user_type.rb
@@ -1,0 +1,6 @@
+class BackfillUserType < ActiveRecord::Migration[5.1]
+  def change
+    User.where(user_type: nil).where.not(api_key: nil).update_all(user_type: :api)
+    User.where(api_key: nil, user_type: nil).update_all(user_type: :download)
+  end
+end

--- a/db/migrate/20180620133920_backfill_user_type.rb
+++ b/db/migrate/20180620133920_backfill_user_type.rb
@@ -1,11 +1,7 @@
 class BackfillUserType < ActiveRecord::Migration[5.1]
   def change
     User.where(user_type: nil).find_each do |u|
-      if u.api_key.present?
-        u.update(user_type: :api)
-      else
-        u.update(user_type: :download)
-      end
+      u.api_key.present? ? u.update(user_type: :api) : u.update(user_type: :download)
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614133521) do
+ActiveRecord::Schema.define(version: 20180620133920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### Context
follow-up to https://github.com/openregister/registers-selfservice/pull/27

### Changes proposed in this pull request
backfill `user_type` for existing users

### Guidance to review
All existing users should have a `user_type` set post-migration.