### PR TITLE
use 2 instances for main app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,6 +14,7 @@ defaults: &defaults
 applications:
   - name: registers-selfservice
     <<: *defaults
+    instances: 2
     health-check-type: http
     health-check-http-endpoint: /health_check/standard
   - name: registers-selfservice-scheduler


### PR DESCRIPTION
### Context
production apps should have more than one instance as per [production checklist](https://docs.cloud.service.gov.uk/deploying_apps.html#production-checklist).

### Changes proposed in this pull request
run 2 instances of `registers-selfservice`. 
N.B. `queue` and `scheduler` are designed to run only one instance to avoid duplicate jobs and queues being created.

### Guidance to review
should deploy successfully through travis ci.
