### PR TITLE
add rake task to perform backfill user type

### DIFF
--- a/lib/tasks/backfill_user_type.rake
+++ b/lib/tasks/backfill_user_type.rake
@@ -1,0 +1,7 @@
+namespace :registers_selfservice do
+  task backfill_user_type: :environment do
+    User.where(user_type: nil).find_each do |u|
+      u.api_key.present? ? u.update(user_type: :api) : u.update(user_type: :download)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Cliff noticed some users registered over a specific timespan were missing `user_type`

### Changes proposed in this pull request
Add task to backfill `user_type`

### Guidance to review
Running task should cause any users with `user_type: nil` to be assigned a correct user type.